### PR TITLE
clamapi-bump-app-2.0.4

### DIFF
--- a/charts/clamapi/Chart.yaml
+++ b/charts/clamapi/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: 2.0.3
+appVersion: 2.0.4
 description: A Helm chart for Kubernetes
 name: clamapi
 home: https://github.com/cnieg/helm-charts/
 sources:
   - https://github.com/audig/clamapi
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: audig

--- a/charts/clamapi/values.yaml
+++ b/charts/clamapi/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: audig/clamapi
-  tag: 2.0.3
+  tag: 2.0.4
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Release note : https://github.com/audig/clamapi/releases/tag/2.0.4
Changelog clamapi : https://github.com/audig/clamapi/compare/2.0.3...2.0.4