### PR TITLE
fix(clamapi): Fix the wrong svc used by default to target clamav

### DIFF
--- a/charts/clamapi/Chart.yaml
+++ b/charts/clamapi/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: 2.1.0
+appVersion: 2.1.6
 description: A Helm chart for Kubernetes
 name: clamapi
 home: https://github.com/cnieg/helm-charts/
 sources:
   - https://github.com/audig/clamapi
-version: 1.2.0
+version: 1.2.2
 maintainers:
   - name: audig

--- a/charts/clamapi/templates/deployment.yaml
+++ b/charts/clamapi/templates/deployment.yaml
@@ -32,11 +32,11 @@ spec:
               protocol: TCP
           env:
             - name: SERVICES_CLAMAV_HOST
-              value:  {{ .Values.clamav.externalHost | default (printf "%s-clamav" .Release.Name) }}
+              value:  {{ .Values.clamav.host  }}
             - name: SERVICES_CLAMAV_TIMEOUT
               value: {{ .Values.clamav.timeout | quote }}
             - name: SERVICES_CLAMAV_PORT
-              value: {{ default "3310" .Values.clamav.externalPort | quote }}
+              value: {{ .Values.clamav.port | quote }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}

--- a/charts/clamapi/values.yaml
+++ b/charts/clamapi/values.yaml
@@ -6,15 +6,15 @@ replicaCount: 1
 
 image:
   repository: audig/clamapi
-  tag: 2.1.0
+  tag: 2.1.6
   pullPolicy: IfNotPresent
 
 
 clamav:
+  #Deployment of clamav can be disabled to use an existing clamav, you must adjust host & port to target your clamav instance
   enabled: true
-  # If clamav enabled false, host & port can be specified to use an external clamav
-  # externalHost:
-  # externalPort:
+  host: clamav
+  port: 3310
   timeout: 1000
   kubeMeta:
     deploymentApiVersion: apps/v1


### PR DESCRIPTION
Replace:  Release-name-clamav to clamav as written in clamav chart dependency