### PR TITLE
feat(passbolt): parametrize port

### DIFF
--- a/charts/passbolt/templates/deployment.yaml
+++ b/charts/passbolt/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.httpPort }}
               protocol: TCP
           env:
             - name: DATASOURCES_DEFAULT_HOST

--- a/charts/passbolt/templates/deployment.yaml
+++ b/charts/passbolt/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.httpPort }}
+              containerPort: {{ .Values.deployment.port }}
               protocol: TCP
           env:
             - name: DATASOURCES_DEFAULT_HOST

--- a/charts/passbolt/values.yaml
+++ b/charts/passbolt/values.yaml
@@ -34,6 +34,9 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+deployment:
+  port: 80
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
For newer versions, passbolt container uses port 80